### PR TITLE
Please change the title of the repo for http://sketchtoolbox.com/ sake

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Please change the title of the repo to something meaninful like https://github.com/jaimeagudo/ArtMold so the users can find the plugin from http://sketchtoolbox.com/, you'll get more visibility. I cannot issue a PR for it :)
+
 # ArtMold
 
 ArtMold is a plugin for Sketch that helps you duplicate and scale the selected artboard with layers in the artboard resizing.You can  alse specify constraint masks  in some layer to control it flexible resizing or fixed .These constraints are relative to the parent, either a group or an artboard.


### PR DESCRIPTION
Please change the title of the repo to something meaninful like https://github.com/jaimeagudo/ArtMold so the users can find the plugin from http://sketchtoolbox.com/, you'll get more visibility. I cannot issue a proper PR for it :)
